### PR TITLE
Fix install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ been evolving in its own direction since then.
 ## Install
 
 ```
-cargo install fart-cli
+cargo install fart
 ```
 
 ## Quick Start


### PR DESCRIPTION
Previous instruction results in

```
error: could not find `fart-cli` in registry `https://github.com/rust-lang/crates.io-index`
```